### PR TITLE
Fix problem with Mockery expectations hiding fails

### DIFF
--- a/src/Mockery.php
+++ b/src/Mockery.php
@@ -24,8 +24,21 @@ use Codeception\TestCase;
  */
 class Mockery extends Module
 {
+    /** @var bool Run mockery expectations after test or not */
+    private $assert_mocks = true;
+
     public function _after(TestCase $test)
     {
-        \Mockery::close();
+        if ($this->assert_mocks) {
+            \Mockery::close();
+        } else {
+            \Mockery::getContainer()->mockery_close();
+            \Mockery::resetContainer();
+        }
+    }
+
+    public function _failed(TestCase $test, $fail)
+    {
+        $this->assert_mocks = false;
     }
 }


### PR DESCRIPTION
_after() is always run, even if a regular assertion fails the test. This causes mockery to hijack the error, if it had any expectations in the test.

This fix prevents Mockery from running its expectations, if the test has already failed. So that the correct failure message is displayed.