### PR TITLE
composer: require mockery/mockery ~1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "mockery/mockery": "~0.8",
+        "mockery/mockery": "^0.8|^0.9|^1.0",
         "codeception/codeception": "^2.0"
     },
     "autoload": {


### PR DESCRIPTION
Require stable version of mockery/mockery

Since upstream introduces BC breaks - it's likely that MockeryModule will also need a version bump.