### PR TITLE
fix: make `tearDown` method compatibile with newer PHPUnit versions

### DIFF
--- a/src/MockeryModule/Test.php
+++ b/src/MockeryModule/Test.php
@@ -16,7 +16,7 @@ use Mockery;
  */
 class Test extends BaseTest
 {
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
         Mockery::close();


### PR DESCRIPTION
Fixes: `Fatal error: Declaration of Codeception\MockeryModule\Test::tearDown() must be compatible with Codeception\PHPUnit\TestCase::tearDown()`